### PR TITLE
chore(core): assert owned FFI wrappers have drop

### DIFF
--- a/src/ffi/test_utils.rs
+++ b/src/ffi/test_utils.rs
@@ -14,6 +14,11 @@ macro_rules! test_owned_trait_requirements {
             assert_send_sync::<$owned>();
             assert_as_ptr::<$owned, $ffi_type>();
             assert_from_mut_ptr::<$owned, $ffi_type>();
+
+            assert!(
+                std::mem::needs_drop::<$owned>(),
+                "owned FFI wrapper must impl Drop to release its handle"
+            );
         }
     };
 }


### PR DESCRIPTION
A wrapper missing its Drop impl leaks its C handle silently. This adds a test to detect Drop implementation for owned types.