### PR TITLE
Fix(core): Fix `TxOutIter::size_hint` to use output count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `verify` now uses an infallible conversion for the internal `ScriptVerifyStatus`, since an unrecognized status can only indicate a build-time mismatch between the bindings and the vendored `libbitcoinkernel` subtree rather than a runtime condition.
 - `ChainstateManager::get_block_tree_entry` now resolves the requested block instead of returning `None` for every input. It passed the address of the `BlockHash` wrapper to the kernel rather than the block hash handle the wrapper owns, so no lookup ever matched an entry in the block tree.
+- `TxOutIter::size_hint` returned the transaction's input count instead of its output count, giving an incorrect hint (and an incorrect `ExactSizeIterator::len`).
 
 ## [0.2.1] 2026-05-20
 

--- a/src/core/transaction.rs
+++ b/src/core/transaction.rs
@@ -2498,6 +2498,28 @@ mod tests {
         assert!(!script_bytes.is_empty());
     }
 
+    #[test]
+    fn test_txout_iter_size_hint_matches_len() {
+        let (tx, _) = get_test_transactions();
+        let count = tx.output_count();
+
+        let mut iter = tx.outputs();
+        for remaining in (0..=count).rev() {
+            assert_eq!(iter.size_hint(), (remaining, Some(remaining)));
+            assert_eq!(iter.len(), remaining);
+            iter.next();
+        }
+
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+        assert_eq!(iter.len(), 0);
+    }
+
+    #[test]
+    fn test_txout_iter_collect_length() {
+        let (tx, _) = get_test_transactions();
+        assert_eq!(tx.outputs().collect::<Vec<_>>().len(), tx.output_count());
+    }
+
     // TxIn tests
     #[test]
     fn test_txin_from_transaction() {
@@ -2592,6 +2614,28 @@ mod tests {
         }
 
         assert_eq!(iter_count, len);
+    }
+
+    #[test]
+    fn test_txin_iter_size_hint_matches_len() {
+        let (tx, _) = get_test_transactions();
+        let count = tx.input_count();
+
+        let mut iter = tx.inputs();
+        for remaining in (0..=count).rev() {
+            assert_eq!(iter.size_hint(), (remaining, Some(remaining)));
+            assert_eq!(iter.len(), remaining);
+            iter.next();
+        }
+
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+        assert_eq!(iter.len(), 0);
+    }
+
+    #[test]
+    fn test_txin_iter_collect_length() {
+        let (tx, _) = get_test_transactions();
+        assert_eq!(tx.inputs().collect::<Vec<_>>().len(), tx.input_count());
     }
 
     // TxOutPoint tests

--- a/src/core/transaction.rs
+++ b/src/core/transaction.rs
@@ -821,7 +821,7 @@ impl<'a> Iterator for TxOutIter<'a> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         let remaining = self
             .transaction
-            .input_count()
+            .output_count()
             .saturating_sub(self.current_index);
         (remaining, Some(remaining))
     }


### PR DESCRIPTION
### Summary

`TxOutIter::size_hint` computed its remaining count from `input_count()` rather than `output_count()`, so on any transaction where the two differ it reported the wrong number of remaining items.

### Why this wasn't caught

Neither iterator had any coverage of `size_hint` or `len`. The existing `test_transaction_outputs_iterator` drives a manual `for` loop with a hand-rolled counter, which only exercises `next()`, so the hint was invisible to the suite.