### PR TITLE
build: set `DCMAKE_POSITION_INDEPENDENT_CODE` to `ON`

### DIFF
--- a/libbitcoinkernel-sys/CHANGELOG.md
+++ b/libbitcoinkernel-sys/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Enabled `CMAKE_POSITION_INDEPENDENT_CODE` when building the kernel. Previously `libbitcoinkernel.a` could not be linked into a shared object on toolchains where Bitcoin Core's PIE probe fails
+
 ## [0.4.0] - 2026-08-26
 
 ### Added

--- a/libbitcoinkernel-sys/build.rs
+++ b/libbitcoinkernel-sys/build.rs
@@ -23,8 +23,10 @@ const BASE_CMAKE_FLAGS: &[&str] = &[
     "-DBUILD_FUZZ_BINARY=OFF",
     "-DBUILD_SHARED_LIBS=OFF",
     "-DCMAKE_INSTALL_LIBDIR=lib",
+    "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
     "-DENABLE_IPC=OFF",
 ];
+
 fn main() {
     let target = target_config();
 


### PR DESCRIPTION
Closes #220 

Bitcoin Core relies on a PIE probe to decide whether it will enable PIC during build. Some setups may fail the PIE probe (e.g. cross-compilation setups), which in turn will not enable PIC. This lead to failure to link with some rust compilers and rust `crate-type`s, such as `riscv64gc-unknown-linux-gnu` and `cdylib`.

Explicitly setting `DCMAKE_POSITION_INDEPENDENT_CODE=ON` resolves the issue.